### PR TITLE
Fixed boards.txt path when using gcc avr toolchain in ubuntu.

### DIFF
--- a/build/Cosa.mk
+++ b/build/Cosa.mk
@@ -32,7 +32,7 @@ ARDMK_DIR = $(COSA_DIR)/build/Arduino-Makefile
 ARDUINO_CORE_PATH = $(COSA_DIR)/cores/cosa
 ARDUINO_VAR_PATH = $(COSA_DIR)/variants
 ARDUINO_LIB_PATH = $(COSA_DIR)/libraries
-BOARDS_TXT = $(COSA_DIR)/build/boards.txt
+BOARDS_TXT = $(COSA_DIR)/boards.txt
 
 MONITOR_CMD = $(COSA_DIR)/build/miniterm.py -q --lf
 


### PR DESCRIPTION
When USING COSA WITH THE GCC AVR TOOLCHAIN (UBUNTU), running the command:

`cosa boards`

Gives an error in which it cannot find the boards.txt file in path: $(COSA_DIR)/build/boards.txt
